### PR TITLE
web: drop redundant WriteHeader call.

### DIFF
--- a/web/method_handlers.go
+++ b/web/method_handlers.go
@@ -44,8 +44,6 @@ func (m noRequestMethodHandler[Response]) ServeHTTP(w http.ResponseWriter, _ *ht
 			"response": resp,
 		},
 	).Debug("response")
-
-	w.WriteHeader(http.StatusOK)
 }
 
 // methodHandler is a wrapper around a service method
@@ -100,6 +98,4 @@ func (m methodHandler[Request, Response]) ServeHTTP(w http.ResponseWriter, req *
 		m.logger.WithError(err).Error("encoding response failed")
 		return
 	}
-
-	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
This MR get's rid of ` superfluous response.WriteHeader call from github.com/kaznasho/yarmarok/logger.(*LoggingResponseWriter).WriteHeader (logger.go:79)` from logs.