### PR TITLE
fix: update participant with provided data during edit action

### DIFF
--- a/service/participant.go
+++ b/service/participant.go
@@ -77,6 +77,10 @@ func (pm *ParticipantManager) Edit(p *ParticipantEditRequest) (*Result, error) {
 		return &Result{StatusError}, err
 	}
 
+	participant.Name = p.Name
+	participant.Phone = p.Phone
+	participant.Note = p.Note
+
 	if err := pm.participantStorage.Update(participant); err != nil {
 		return &Result{StatusError}, err
 	}


### PR DESCRIPTION
During the Edit action, we have to get the original participant from the storage and update it with the provided request data. 
We don't want to allow changing some attributes like ID etc. To achieve that reusing the models we can just set the new values to the original participant and continue using it for the storage update operation. 

P.S.: ideally we have to use separate models for storage lvl calls. In such a case they would contain only those attributes that are allowed to modify. 