### PR TITLE
PROPOSAL: refactor: align entities creation naming

### DIFF
--- a/function/entrypoint_test.go
+++ b/function/entrypoint_test.go
@@ -40,7 +40,7 @@ func TestLoadRouter(t *testing.T) {
 
 		router.ServeHTTP(recorder, req)
 
-		resp := service.InitResult{}
+		resp := service.CreateResult{}
 
 		assert.Equal(t, http.StatusOK, recorder.Code)
 		assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp), recorder.Body.String())
@@ -72,7 +72,7 @@ func TestEntrypoint(t *testing.T) {
 
 		Entrypoint(recorder, req)
 
-		resp := service.InitResult{}
+		resp := service.CreateResult{}
 
 		assert.Equal(t, http.StatusOK, recorder.Code)
 		assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp), recorder.Body.String())

--- a/service/organizer.go
+++ b/service/organizer.go
@@ -32,7 +32,7 @@ type OrganizerStorage interface {
 
 // OrganizerService is a service for organizers.
 type OrganizerService interface {
-	InitOrganizerIfNotExists(id string) error
+	CreateOrganizerIfNotExists(id string) error
 	RaffleService(organizerID string) RaffleService
 }
 
@@ -48,8 +48,8 @@ func NewOrganizerManager(os OrganizerStorage) *OrganizerManager {
 	}
 }
 
-// InitOrganizerIfNotExists initializes an organizer if it does not exist.
-func (om *OrganizerManager) InitOrganizerIfNotExists(id string) error {
+// CreateOrganizerIfNotExists creates an organizer if it does not exist.
+func (om *OrganizerManager) CreateOrganizerIfNotExists(id string) error {
 	exists, err := om.organizerStorage.Exists(id)
 	if err != nil {
 		return err

--- a/service/organizer_test.go
+++ b/service/organizer_test.go
@@ -19,7 +19,7 @@ func TestInitOrganizer(t *testing.T) {
 			osMock.EXPECT().Exists(organizerID).Return(true, nil)
 			om := NewOrganizerManager(osMock)
 
-			err := om.InitOrganizerIfNotExists(organizerID)
+			err := om.CreateOrganizerIfNotExists(organizerID)
 			assert.NoError(t, err)
 		})
 
@@ -29,7 +29,7 @@ func TestInitOrganizer(t *testing.T) {
 			osMock.EXPECT().Create(&Organizer{ID: organizerID}).Return(nil)
 			om := NewOrganizerManager(osMock)
 
-			err := om.InitOrganizerIfNotExists(organizerID)
+			err := om.CreateOrganizerIfNotExists(organizerID)
 			assert.NoError(t, err)
 		})
 
@@ -38,7 +38,7 @@ func TestInitOrganizer(t *testing.T) {
 			osMock.EXPECT().Exists(organizerID).Return(false, assert.AnError)
 			om := NewOrganizerManager(osMock)
 
-			err := om.InitOrganizerIfNotExists(organizerID)
+			err := om.CreateOrganizerIfNotExists(organizerID)
 			assert.Error(t, err)
 		})
 	})

--- a/service/participant.go
+++ b/service/participant.go
@@ -36,7 +36,7 @@ type ParticipantListResult struct {
 
 // ParticipantService is a service for participants.
 type ParticipantService interface {
-	Add(p *ParticipantAddRequest) (*InitResult, error)
+	Create(p *ParticipantAddRequest) (*CreateResult, error)
 	Edit(p *ParticipantEditRequest) (*Result, error)
 	List() (*ParticipantListResult, error)
 }
@@ -60,17 +60,17 @@ func NewParticipantManager(ps ParticipantStorage) *ParticipantManager {
 	return &ParticipantManager{participantStorage: ps}
 }
 
-// Add creates a new participant
-func (pm *ParticipantManager) Add(p *ParticipantAddRequest) (*InitResult, error) {
+// Create creates a new participant.
+func (pm *ParticipantManager) Create(p *ParticipantAddRequest) (*CreateResult, error) {
 	participant := toParticipant(p)
 	if err := pm.participantStorage.Create(participant); err != nil {
 		return nil, err
 	}
 
-	return &InitResult{ID: participant.ID}, nil
+	return &CreateResult{ID: participant.ID}, nil
 }
 
-// Edit updates a participant
+// Edit updates a participant.
 func (pm *ParticipantManager) Edit(p *ParticipantEditRequest) (*Result, error) {
 	participant, err := pm.participantStorage.Get(p.ID)
 	if err != nil {

--- a/service/participant_test.go
+++ b/service/participant_test.go
@@ -18,7 +18,7 @@ func TestParticipantManagerAdd(t *testing.T) {
 	t.Run("add participant", func(t *testing.T) {
 		storageMock.EXPECT().Create(gomock.Any()).Return(nil)
 
-		_, err := manager.Add(&ParticipantAddRequest{
+		_, err := manager.Create(&ParticipantAddRequest{
 			Name:  "John Doe",
 			Phone: "1234567890",
 			Note:  "Test participant",
@@ -35,7 +35,7 @@ func TestParticipantManagerAdd(t *testing.T) {
 
 		participantManager := NewParticipantManager(storageMock)
 
-		_, err := participantManager.Add(&ParticipantAddRequest{
+		_, err := participantManager.Create(&ParticipantAddRequest{
 			Name:  "John Doe",
 			Phone: "1234567890",
 			Note:  "Test participant",

--- a/service/prize.go
+++ b/service/prize.go
@@ -19,8 +19,8 @@ type Prize struct {
 	CreatedAt   time.Time
 }
 
-// PrizeAddRequest is a request for creating a new prize.
-type PrizeAddRequest struct {
+// PrizeCreateRequest is a request for creating a new prize.
+type PrizeCreateRequest struct {
 	Name        string
 	TicketCost  int
 	Description string
@@ -36,7 +36,7 @@ type PrizeListResult struct {
 
 // PrizeService is a service for prizes.
 type PrizeService interface {
-	Add(p *PrizeAddRequest) (*InitResult, error)
+	Create(p *PrizeCreateRequest) (*CreateResult, error)
 	Edit(p *PrizeEditRequest) (*Result, error)
 	List() (*PrizeListResult, error)
 }
@@ -60,14 +60,14 @@ func NewPrizeManager(ps PrizeStorage) *PrizeManager {
 	return &PrizeManager{prizeStorage: ps}
 }
 
-// Add creates a new prize
-func (pm *PrizeManager) Add(p *PrizeAddRequest) (*InitResult, error) {
+// Create creates a new prize
+func (pm *PrizeManager) Create(p *PrizeCreateRequest) (*CreateResult, error) {
 	prize := toPrize(p)
 	if err := pm.prizeStorage.Create(prize); err != nil {
 		return nil, err
 	}
 
-	return &InitResult{ID: prize.ID}, nil
+	return &CreateResult{ID: prize.ID}, nil
 }
 
 // Edit updates a Prize TODO: edit after donate representation
@@ -94,7 +94,7 @@ func (pm *PrizeManager) List() (*PrizeListResult, error) {
 	return &PrizeListResult{Prizes: prizes}, nil
 }
 
-func toPrize(p *PrizeAddRequest) *Prize {
+func toPrize(p *PrizeCreateRequest) *Prize {
 	return &Prize{
 		ID:          stringUUID(),
 		Name:        p.Name,

--- a/service/prize_test.go
+++ b/service/prize_test.go
@@ -21,7 +21,7 @@ func TestPrizeManager(t *testing.T) {
 		t.Run("prize_success", func(t *testing.T) {
 			storageMock.EXPECT().Create(gomock.Any()).Return(nil)
 
-			res, err := manager.Add(&PrizeAddRequest{
+			res, err := manager.Create(&PrizeCreateRequest{
 				Name:        "prize_name_1",
 				TicketCost:  1234,
 				Description: "prize_description_1",
@@ -36,7 +36,7 @@ func TestPrizeManager(t *testing.T) {
 
 			prizeManager := NewPrizeManager(storageMock)
 
-			res, err := prizeManager.Add(&PrizeAddRequest{
+			res, err := prizeManager.Create(&PrizeCreateRequest{
 				Name:        "prize_name_1",
 				TicketCost:  1234,
 				Description: "prize_description_1",

--- a/service/raffle.go
+++ b/service/raffle.go
@@ -38,7 +38,7 @@ type Raffle struct {
 
 // RaffleService is a service for raffles.
 type RaffleService interface {
-	Init(*RaffleInitRequest) (*InitResult, error)
+	Create(*RaffleInitRequest) (*CreateResult, error)
 	Get(id string) (*Raffle, error)
 	List() (*RaffleListResponse, error)
 	Export(id string) (*RaffleExportResponse, error)
@@ -67,8 +67,8 @@ func NewRaffleManager(rs RaffleStorage) *RaffleManager {
 	}
 }
 
-// Init initializes a raffle.
-func (rm *RaffleManager) Init(raf *RaffleInitRequest) (*InitResult, error) {
+// Create initializes a raffle.
+func (rm *RaffleManager) Create(raf *RaffleInitRequest) (*CreateResult, error) {
 	raffle := Raffle{
 		ID:        stringUUID(),
 		Name:      raf.Name,
@@ -81,7 +81,7 @@ func (rm *RaffleManager) Init(raf *RaffleInitRequest) (*InitResult, error) {
 		return nil, err
 	}
 
-	return &InitResult{
+	return &CreateResult{
 		ID: raffle.ID,
 	}, nil
 }
@@ -150,8 +150,8 @@ type RaffleInitRequest struct {
 	Note string `json:"note"`
 }
 
-// InitResult is a generic result of entity initialization.
-type InitResult struct {
+// CreateResult is a generic result of entity creation.
+type CreateResult struct {
 	ID string `json:"id"`
 }
 

--- a/service/raffle_test.go
+++ b/service/raffle_test.go
@@ -29,7 +29,7 @@ func TestRaffle(t *testing.T) {
 
 			storageMock.EXPECT().Create(gomock.Any()).Return(mockedErr).Times(1)
 
-			res, err := manager.Init(&req)
+			res, err := manager.Create(&req)
 			assert.Error(t, err)
 			assert.Equal(t, mockedErr, err)
 			assert.Nil(t, res)
@@ -56,7 +56,7 @@ func TestRaffle(t *testing.T) {
 
 			storageMock.EXPECT().Create(mockedRaffle).Return(nil).Times(1)
 
-			res, err := manager.Init(&req)
+			res, err := manager.Create(&req)
 			assert.NoError(t, err)
 			assert.Equal(t, mockedID, res.ID)
 		})

--- a/web/middleware.go
+++ b/web/middleware.go
@@ -26,7 +26,7 @@ func (r *Router) organizerMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		err = r.organizerService.InitOrganizerIfNotExists(organizerID)
+		err = r.organizerService.CreateOrganizerIfNotExists(organizerID)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			r.logger.WithError(err).Error("failed to init organizer")

--- a/web/mocks/mock_organizer.go
+++ b/web/mocks/mock_organizer.go
@@ -34,18 +34,18 @@ func (m *MockOrganizerService) EXPECT() *MockOrganizerServiceMockRecorder {
 	return m.recorder
 }
 
-// InitOrganizerIfNotExists mocks base method.
-func (m *MockOrganizerService) InitOrganizerIfNotExists(arg0 string) error {
+// CreateOrganizerIfNotExists mocks base method.
+func (m *MockOrganizerService) CreateOrganizerIfNotExists(arg0 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitOrganizerIfNotExists", arg0)
+	ret := m.ctrl.Call(m, "CreateOrganizerIfNotExists", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// InitOrganizerIfNotExists indicates an expected call of InitOrganizerIfNotExists.
-func (mr *MockOrganizerServiceMockRecorder) InitOrganizerIfNotExists(arg0 interface{}) *gomock.Call {
+// CreateOrganizerIfNotExists indicates an expected call of CreateOrganizerIfNotExists.
+func (mr *MockOrganizerServiceMockRecorder) CreateOrganizerIfNotExists(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitOrganizerIfNotExists", reflect.TypeOf((*MockOrganizerService)(nil).InitOrganizerIfNotExists), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrganizerIfNotExists", reflect.TypeOf((*MockOrganizerService)(nil).CreateOrganizerIfNotExists), arg0)
 }
 
 // RaffleService mocks base method.

--- a/web/mocks/mock_participant.go
+++ b/web/mocks/mock_participant.go
@@ -34,19 +34,19 @@ func (m *MockParticipantService) EXPECT() *MockParticipantServiceMockRecorder {
 	return m.recorder
 }
 
-// Add mocks base method.
-func (m *MockParticipantService) Add(arg0 *service.ParticipantAddRequest) (*service.InitResult, error) {
+// Create mocks base method.
+func (m *MockParticipantService) Create(arg0 *service.ParticipantAddRequest) (*service.CreateResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Add", arg0)
-	ret0, _ := ret[0].(*service.InitResult)
+	ret := m.ctrl.Call(m, "Create", arg0)
+	ret0, _ := ret[0].(*service.CreateResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Add indicates an expected call of Add.
-func (mr *MockParticipantServiceMockRecorder) Add(arg0 interface{}) *gomock.Call {
+// Create indicates an expected call of Create.
+func (mr *MockParticipantServiceMockRecorder) Create(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockParticipantService)(nil).Add), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockParticipantService)(nil).Create), arg0)
 }
 
 // Edit mocks base method.

--- a/web/mocks/mock_raffle.go
+++ b/web/mocks/mock_raffle.go
@@ -34,6 +34,21 @@ func (m *MockRaffleService) EXPECT() *MockRaffleServiceMockRecorder {
 	return m.recorder
 }
 
+// Create mocks base method.
+func (m *MockRaffleService) Create(arg0 *service.RaffleInitRequest) (*service.CreateResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", arg0)
+	ret0, _ := ret[0].(*service.CreateResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockRaffleServiceMockRecorder) Create(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockRaffleService)(nil).Create), arg0)
+}
+
 // Export mocks base method.
 func (m *MockRaffleService) Export(arg0 string) (*service.RaffleExportResponse, error) {
 	m.ctrl.T.Helper()
@@ -62,21 +77,6 @@ func (m *MockRaffleService) Get(arg0 string) (*service.Raffle, error) {
 func (mr *MockRaffleServiceMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockRaffleService)(nil).Get), arg0)
-}
-
-// Init mocks base method.
-func (m *MockRaffleService) Init(arg0 *service.RaffleInitRequest) (*service.InitResult, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Init", arg0)
-	ret0, _ := ret[0].(*service.InitResult)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Init indicates an expected call of Init.
-func (mr *MockRaffleServiceMockRecorder) Init(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockRaffleService)(nil).Init), arg0)
 }
 
 // List mocks base method.

--- a/web/router.go
+++ b/web/router.go
@@ -90,7 +90,7 @@ func (r *Router) createRaffle(w http.ResponseWriter, req *http.Request) {
 
 	raffleService := r.organizerService.RaffleService(organizerID)
 
-	m := newMethodHandler(raffleService.Init, r.logger.Logger)
+	m := newMethodHandler(raffleService.Create, r.logger.Logger)
 
 	m.ServeHTTP(w, req)
 }
@@ -146,7 +146,7 @@ func (r *Router) createParticipant(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	newMethodHandler(participantService.Add, r.logger.Logger).ServeHTTP(w, req)
+	newMethodHandler(participantService.Create, r.logger.Logger).ServeHTTP(w, req)
 }
 
 func (r *Router) updateParticipant(w http.ResponseWriter, req *http.Request) {

--- a/web/router_test.go
+++ b/web/router_test.go
@@ -45,7 +45,7 @@ func TestRouter(t *testing.T) {
 		require.NoError(t, err)
 
 		req.Header.Set(GoogleUserIDHeader, organizerID)
-		osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+		osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 		rsMock := mocks.NewMockRaffleService(ctrl)
 		osMock.EXPECT().RaffleService(organizerID).Return(rsMock).Do(func(string) { panic("panic in handler") })
@@ -62,7 +62,7 @@ func TestRouter(t *testing.T) {
 		require.NoError(t, err)
 
 		req.Header.Set(GoogleUserIDHeader, organizerID)
-		osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+		osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 		writer := httptest.NewRecorder()
 		router.ServeHTTP(writer, req)
@@ -89,12 +89,12 @@ func TestRouter(t *testing.T) {
 				require.NoError(t, err)
 
 				req.Header.Set(GoogleUserIDHeader, organizerID)
-				osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+				osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 				rsMock := mocks.NewMockRaffleService(ctrl)
 				osMock.EXPECT().RaffleService(organizerID).Return(rsMock)
 
-				rsMock.EXPECT().Init(initRequest).Return(&service.InitResult{}, nil)
+				rsMock.EXPECT().Create(initRequest).Return(&service.CreateResult{}, nil)
 
 				writer := httptest.NewRecorder()
 				router.ServeHTTP(writer, req)
@@ -116,13 +116,13 @@ func TestRouter(t *testing.T) {
 				require.NoError(t, err)
 
 				req.Header.Set(GoogleUserIDHeader, organizerID)
-				osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+				osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 				rsMock := mocks.NewMockRaffleService(ctrl)
 				osMock.EXPECT().RaffleService(organizerID).Return(rsMock)
 
 				mockedErr := assert.AnError
-				rsMock.EXPECT().Init(initRequest).Return(nil, mockedErr)
+				rsMock.EXPECT().Create(initRequest).Return(nil, mockedErr)
 
 				writer := httptest.NewRecorder()
 				router.ServeHTTP(writer, req)
@@ -134,7 +134,7 @@ func TestRouter(t *testing.T) {
 				require.NoError(t, err)
 
 				req.Header.Set(GoogleUserIDHeader, organizerID)
-				osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+				osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 				rsMock := mocks.NewMockRaffleService(ctrl)
 				osMock.EXPECT().RaffleService(organizerID).Return(rsMock)
@@ -175,7 +175,7 @@ func TestRouter(t *testing.T) {
 				require.NoError(t, err)
 
 				req.Header.Set(GoogleUserIDHeader, organizerID)
-				osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+				osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 				rsMock := mocks.NewMockRaffleService(ctrl)
 				osMock.EXPECT().RaffleService(organizerID).Return(rsMock)
@@ -195,7 +195,7 @@ func TestRouter(t *testing.T) {
 				require.NoError(t, err)
 
 				req.Header.Set(GoogleUserIDHeader, organizerID)
-				osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+				osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 				rsMock := mocks.NewMockRaffleService(ctrl)
 				osMock.EXPECT().RaffleService(organizerID).Return(rsMock)
@@ -218,7 +218,7 @@ func TestRouter(t *testing.T) {
 				require.NoError(t, err)
 
 				req.Header.Set(GoogleUserIDHeader, organizerID)
-				osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+				osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 				rsMock := mocks.NewMockRaffleService(ctrl)
 				osMock.EXPECT().RaffleService(organizerID).Return(rsMock)
@@ -240,7 +240,7 @@ func TestRouter(t *testing.T) {
 				require.NoError(t, err)
 
 				req.Header.Set(GoogleUserIDHeader, organizerID)
-				osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+				osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 				rsMock := mocks.NewMockRaffleService(ctrl)
 				osMock.EXPECT().RaffleService(organizerID).Return(rsMock)
@@ -277,7 +277,7 @@ func TestRouter(t *testing.T) {
 				require.NoError(t, err)
 
 				req.Header.Set(GoogleUserIDHeader, organizerID)
-				osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+				osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 				rsMock := mocks.NewMockRaffleService(ctrl)
 				osMock.EXPECT().RaffleService(organizerID).Return(rsMock)
@@ -285,8 +285,8 @@ func TestRouter(t *testing.T) {
 				psMock := mocks.NewMockParticipantService(ctrl)
 				rsMock.EXPECT().ParticipantService(raffleID).Return(psMock)
 
-				expect := &service.InitResult{ID: "participant_id_1"}
-				psMock.EXPECT().Add(participantInitRequest).Return(expect, nil)
+				expect := &service.CreateResult{ID: "participant_id_1"}
+				psMock.EXPECT().Create(participantInitRequest).Return(expect, nil)
 
 				writer := httptest.NewRecorder()
 				router.ServeHTTP(writer, req)
@@ -308,7 +308,7 @@ func TestRouter(t *testing.T) {
 				require.NoError(t, err)
 
 				req.Header.Set(GoogleUserIDHeader, organizerID)
-				osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+				osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 				rsMock := mocks.NewMockRaffleService(ctrl)
 				osMock.EXPECT().RaffleService(organizerID).Return(rsMock)
@@ -316,7 +316,7 @@ func TestRouter(t *testing.T) {
 				psMock := mocks.NewMockParticipantService(ctrl)
 				rsMock.EXPECT().ParticipantService(raffleID).Return(psMock)
 
-				psMock.EXPECT().Add(participantInitRequest).Return(nil, errors.New("test error"))
+				psMock.EXPECT().Create(participantInitRequest).Return(nil, errors.New("test error"))
 
 				writer := httptest.NewRecorder()
 				router.ServeHTTP(writer, req)
@@ -328,7 +328,7 @@ func TestRouter(t *testing.T) {
 				require.NoError(t, err)
 
 				req.Header.Set(GoogleUserIDHeader, organizerID)
-				osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+				osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 				rsMock := mocks.NewMockRaffleService(ctrl)
 				osMock.EXPECT().RaffleService(organizerID).Return(rsMock)
@@ -359,7 +359,7 @@ func TestRouter(t *testing.T) {
 				require.NoError(t, err)
 
 				req.Header.Set(GoogleUserIDHeader, organizerID)
-				osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+				osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 				rsMock := mocks.NewMockRaffleService(ctrl)
 				osMock.EXPECT().RaffleService(organizerID).Return(rsMock)
@@ -390,7 +390,7 @@ func TestRouter(t *testing.T) {
 				require.NoError(t, err)
 
 				req.Header.Set(GoogleUserIDHeader, organizerID)
-				osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+				osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 				rsMock := mocks.NewMockRaffleService(ctrl)
 				osMock.EXPECT().RaffleService(organizerID).Return(rsMock)
@@ -410,7 +410,7 @@ func TestRouter(t *testing.T) {
 				require.NoError(t, err)
 
 				req.Header.Set(GoogleUserIDHeader, organizerID)
-				osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+				osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 				rsMock := mocks.NewMockRaffleService(ctrl)
 				osMock.EXPECT().RaffleService(organizerID).Return(rsMock)
@@ -457,7 +457,7 @@ func TestRouter(t *testing.T) {
 				require.NoError(t, err)
 
 				req.Header.Set(GoogleUserIDHeader, organizerID)
-				osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+				osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 				rsMock := mocks.NewMockRaffleService(ctrl)
 				osMock.EXPECT().RaffleService(organizerID).Return(rsMock)
@@ -477,7 +477,7 @@ func TestRouter(t *testing.T) {
 				require.NoError(t, err)
 
 				req.Header.Set(GoogleUserIDHeader, organizerID)
-				osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+				osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 				rsMock := mocks.NewMockRaffleService(ctrl)
 				osMock.EXPECT().RaffleService(organizerID).Return(rsMock)
@@ -511,7 +511,7 @@ func TestApplyOrganizerMiddleware(t *testing.T) {
 		require.NoError(t, err)
 
 		req.Header.Set(GoogleUserIDHeader, organizerID)
-		osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil)
+		osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil)
 
 		stub := newHandlerStub()
 		handler := http.HandlerFunc(stub.ServeHTTP)
@@ -545,7 +545,7 @@ func TestApplyOrganizerMiddleware(t *testing.T) {
 		mockedErr := errors.New("mocked error")
 
 		req.Header.Set(GoogleUserIDHeader, organizerID)
-		osMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(mockedErr)
+		osMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(mockedErr)
 
 		writer := httptest.NewRecorder()
 		router.organizerMiddleware(handler).ServeHTTP(writer, req)
@@ -627,7 +627,7 @@ func TestGeParticipantService(t *testing.T) {
 	rsMock := mocks.NewMockRaffleService(ctrl)
 	psMock := mocks.NewMockParticipantService(ctrl)
 
-	usMock.EXPECT().InitOrganizerIfNotExists(organizerID).Return(nil).AnyTimes()
+	usMock.EXPECT().CreateOrganizerIfNotExists(organizerID).Return(nil).AnyTimes()
 	usMock.EXPECT().RaffleService(organizerID).Return(rsMock).AnyTimes()
 
 	router, err := NewRouter(usMock, logger.NewLogger(logger.LevelDebug))


### PR DESCRIPTION
The goal of this proposal is to have the same naming for different entities creation operations.
Just to avoid the confusion between init/add/create. 